### PR TITLE
Add async parameter to get back conversation id

### DIFF
--- a/test/MessageMock.ts
+++ b/test/MessageMock.ts
@@ -20,6 +20,34 @@ export class MessageMock {
         const baseURL = process.env.VIRTUAL_DEVICE_BASE_URL
             ? process.env.VIRTUAL_DEVICE_BASE_URL
             : "https://virtual-device.bespoken.io";
+        nock(baseURL)
+            .persist()
+            .post("/batch_process")
+            .query(function(queryObject: any) {
+                return !queryObject.async_mode;
+            })
+            .reply(200, function(uri: string, requestBody: any) {
+                if (MessageMock.onCallCallback) {
+                    MessageMock.onCallCallback(uri, requestBody);
+                }
+                return processBatchMessages(requestBody);
+            });
+
+        nock(baseURL)
+            .persist()
+            .post("/batch_process")
+            .query(function(queryObject: any) {
+                return queryObject.async_mode;
+            })
+            .reply(200, function(uri: string, requestBody: any) {
+                if (MessageMock.onCallCallback) {
+                    MessageMock.onCallCallback(uri, requestBody);
+                }
+                return {
+                    uuid: "generated-uuid",
+                };
+            });
+        // Mock f
         // Mock for batch process call
         nock(baseURL)
             .persist()

--- a/test/VirtualDeviceTest.ts
+++ b/test/VirtualDeviceTest.ts
@@ -176,6 +176,19 @@ describe("VirtualDevice", function() {
             assert.equal(port, 80);
         });
     });
+
+    describe("Async batch process", () => {
+        before(() => {
+            MessageMock.enable();
+        });
+
+        it("return conversation uuid", async () => {
+            const sdk = new VirtualDevice("DUMMY_TOKEN", "de-DE", "DUMMY_VOICE", undefined, true);
+
+            const results = await sdk.batchMessage([{text: "wie spät ist es"}, {text: "Wie ist das Wetter"}]);
+            assert.equal(results.uuid, "generated-uuid");
+        });
+    });
 });
 
 function newVirtualDevice() {


### PR DESCRIPTION
Relates to https://github.com/bespoken/virtual-device-sdk/issues/100

Adding async as a constructor parameter, and receive the conversation id as a result when doing a batch_process